### PR TITLE
Removed TestCommand setup due to setuptools update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
  - source activate testenv
  - python setup.py install
  - pip install coveralls
+ # Workaround for image_comparison issue in v1.5.0 of matplotlib
+ - pip install git+https://github.com/matplotlib/matplotlib.git
 script:
  - coverage run --source=SALib --omit=SALib/_version.py setup.py test
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,6 @@ versioneer.parentdir_prefix = 'SALib-' # dirname like 'myproject-1.2.0'
 
 class NoseTestCommand(TestCommand):
 
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
     def run_tests(self):
         # Run nose ensuring that argv simulates running nosetests directly
         import nose


### PR DESCRIPTION
Removed the `finalise_options` part of the setup script as the latest version of setuptools does this automatically, and added a `pip install` for the latest development version of matplotlib